### PR TITLE
Initial release workflow

### DIFF
--- a/.github/workflows/chat-ops.yml
+++ b/.github/workflows/chat-ops.yml
@@ -1,0 +1,16 @@
+name: Chat Ops
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  launcher:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Command Dispatch
+      uses: peter-evans/slash-command-dispatch@v1
+      with:
+        token: ${{ secrets.ACTIONS_TOKEN }}
+        commands: release, release-rc, promote
+        named-args: true

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,54 @@
+name: Promote Dispatch
+
+on:
+  repository_dispatch:
+    types: [promote-command]
+jobs:
+  promote-release:
+    if: ${{ github.event.client_payload.slash_command.env }} && ${{ github.event.client_payload.slash_command.name }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set Env Variables
+      id: env_info
+      run: |
+        echo ::set-output name=requestor::$(jq .client_payload.github.actor $GITHUB_EVENT_PATH)
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.slash_command.name }}
+    - name: GitHub Pull Request Action
+      id: create_pr
+      uses: repo-sync/pull-request@v2.2
+      with:
+        source_branch: ${{ github.event.client_payload.slash_command.name }}
+        destination_branch: ${{ github.event.client_payload.slash_command.env }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pr_title: "Promoting ${{ github.event.client_payload.slash_command.name }} to ${{ github.event.client_payload.slash_command.env }}"
+        pr_body: "Promoting release ${{ github.event.client_payload.slash_command.name }} to the ${{ github.event.client_payload.slash_command.env }} environment as requested by @${{ steps.env_info.outputs.requestor }}."
+    - name: Get PR number
+      id: pr_num
+      run: |
+        echo ::set-output name=prnm::$( echo ${{ steps.create_pr.outputs.pr_url }} | awk -F'/' '{print $NF}')
+    - name: Apply label to issue
+      uses: actions/github-script@v2
+      if: ${{ steps.create_pr.outcome == 'success' }}
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: ${{steps.pr_num.outputs.prnm}},
+            labels: ["${{github.event.client_payload.slash_command.name }}"]
+          })
+    - name: Auto-merge
+      uses: actions/github-script@v2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.pulls.merge({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: ${{ steps.pr_num.outputs.prnm}},
+            merge_method: "squash"
+          })
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,37 +77,37 @@ jobs:
       if: ${{ github.event.client_payload.slash_command.frontend != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName frontendVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.frontend ${{ github.event.client_payload.slash_command.frontend }}"
+        cmd: "yq w -i --anchorName frontendVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.frontend ${{ github.event.client_payload.slash_command.frontend }}"
     - name: Update Backend Release
       if: ${{ github.event.client_payload.slash_command.backend != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName backendVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.backend ${{ github.event.client_payload.slash_command.backend }}"
+        cmd: "yq w -i --anchorName backendVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.backend ${{ github.event.client_payload.slash_command.backend }}"
     - name: Update Git API Release
       if: ${{ github.event.client_payload.slash_command.gitapi != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName gitApiVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.git-api ${{ github.event.client_payload.slash_command.gitapi }}"
+        cmd: "yq w -i --anchorName gitApiVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.git-api ${{ github.event.client_payload.slash_command.gitapi }}"
     - name: Update Resource Dispatcher Release
       if: ${{ github.event.client_payload.slash_command.dispatcher != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName resourceDispatcherVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.resource-dispatcher ${{ github.event.client_payload.slash_command.dispatcher }}"
+        cmd: "yq w -i --anchorName resourceDispatcherVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.resource-dispatcher ${{ github.event.client_payload.slash_command.dispatcher }}"
     - name: Update AgnosticV Operator Release
       if: ${{ github.event.client_payload.slash_command.agnosticv != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName agnosticvVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.agnosticv-operator ${{ github.event.client_payload.slash_command.agnosticv }}"
+        cmd: "yq w -i --anchorName agnosticvVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.agnosticv-operator ${{ github.event.client_payload.slash_command.agnosticv }}"
     - name: Update Anarchy Operator Release
       if: ${{ github.event.client_payload.slash_command.anarchy != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName anarchyVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.anarchy-operator ${{ github.event.client_payload.slash_command.anarchy }}"
+        cmd: "yq w -i --anchorName anarchyVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.anarchy-operator ${{ github.event.client_payload.slash_command.anarchy }}"
     - name: Update Poolboy Release
       if: ${{ github.event.client_payload.slash_command.poolboy != null }}
       uses: mikefarah/yq@3.3.2
       with:
-        cmd: "yq w -i --anchorName poolboyVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.poolboy ${{ github.event.client_payload.slash_command.poolboy }}"
+        cmd: "yq w -i --anchorName poolboyVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.poolboy ${{ github.event.client_payload.slash_command.poolboy }}"
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,116 @@
+name: Release Dispatch
+
+on:
+  repository_dispatch:
+    types: [release-command]
+jobs:
+  create-release-branch:
+    if: ${{ github.event.client_payload.slash_command.name }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get Environment Info
+      id: env_info
+      run: |
+        echo ::set-output name=release::$(git ls-remote --heads https://github.com/$GITHUB_REPOSITORY ${{ github.event.client_payload.slash_command.name }})
+        echo ::set-output name=issuenm::$(jq .client_payload.github.payload.issue.number $GITHUB_EVENT_PATH)
+    - name: Create release branch
+      uses: peterjgrainger/action-create-branch@v1.0.0
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        branch: ${{ github.event.client_payload.slash_command.name }}
+      if: ${{ steps.env_info.outputs.release == null }}
+    - name: Alert that release already exists
+      run: |
+        echo "Release branch ${{ github.event.client_payload.slash_command.name }} already exists. Skipping..."
+      if: ${{ steps.env_info.outputs.release != null }}
+    - name: Check if label exists
+      uses: actions/github-script@v1
+      id: label_check
+      continue-on-error: true
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          github.issues.getLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: "${{ github.event.client_payload.slash_command.name }}"
+          })
+    - name: Create label to be used for release
+      uses: actions/github-script@v1
+      id: create_label
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.createLabel({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            name: "${{ github.event.client_payload.slash_command.name }}",
+            color: "2d5893"
+          })
+      if: ${{ steps.label_check.outcome == 'failure' }}
+    - name: Apply label to issue
+      uses: actions/github-script@v1
+      if: ${{ steps.create_label.outcome == 'success' }}
+      with:
+        github-token: ${{secrets.GITHUB_TOKEN}}
+        script: |
+          github.issues.addLabels({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: ${{steps.env_info.outputs.issuenm}},
+            labels: ["${{github.event.client_payload.slash_command.name }}"]
+          })
+
+  update-release-pointers:
+    runs-on: ubuntu-latest
+    needs: create-release-branch
+    steps:
+    - name: Get Environment Info
+      id: env_info
+      run: |
+        echo ::set-output name=comment_url::$(jq .client_payload.github.payload.comment.html_url $GITHUB_EVENT_PATH)
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.client_payload.slash_command.name }}
+    - name: Update Frontend Release
+      if: ${{ github.event.client_payload.slash_command.frontend != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName frontendVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.frontend ${{ github.event.client_payload.slash_command.frontend }}"
+    - name: Update Backend Release
+      if: ${{ github.event.client_payload.slash_command.backend != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName backendVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.backend ${{ github.event.client_payload.slash_command.backend }}"
+    - name: Update Git API Release
+      if: ${{ github.event.client_payload.slash_command.gitapi != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName gitApiVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.git-api ${{ github.event.client_payload.slash_command.gitapi }}"
+    - name: Update Resource Dispatcher Release
+      if: ${{ github.event.client_payload.slash_command.dispatcher != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName resourceDispatcherVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.resource-dispatcher ${{ github.event.client_payload.slash_command.dispatcher }}"
+    - name: Update AgnosticV Operator Release
+      if: ${{ github.event.client_payload.slash_command.agnosticv != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName agnosticvVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.agnosticv-operator ${{ github.event.client_payload.slash_command.agnosticv }}"
+    - name: Update Anarchy Operator Release
+      if: ${{ github.event.client_payload.slash_command.anarchy != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName anarchyVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.anarchy-operator ${{ github.event.client_payload.slash_command.anarchy }}"
+    - name: Update Poolboy Release
+      if: ${{ github.event.client_payload.slash_command.poolboy != null }}
+      uses: mikefarah/yq@3.3.2
+      with:
+        cmd: "yq w -i --anchorName poolboyVersion $GITHUB_WORKSPACE/values.yaml applicationVersions.poolboy ${{ github.event.client_payload.slash_command.poolboy }}"
+    - name: Commit changes
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        branch: ${{ github.event.client_payload.slash_command.name }}
+        commit_message: "Merging changes requested from ${{ steps.env_info.outputs.comment_url }}"
+

--- a/README.md
+++ b/README.md
@@ -31,3 +31,28 @@ applicationVersions:
 NOTE: Because Helm does not support templating inside of the `values.yaml` file, we need to use [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html) if we want to prevent duplicate definitions of data.
 
 Automatic syncing, pruning, and self healing is enabled for this project - so committing a change to the above manifest and tagging it appropriately as `deploy-staging` or `deploy-production` will cause an Argo CD instance bootstrapped with that tag to deploy those versions of the applications.
+
+## Releases
+
+Creating releases is automated through the use of GitHub Actions Workflows. To create a release, you can just create an issue in this repository and use the below triggers in an issue comment to begin:
+
+`/release` - This trigger along with the appropriate parameters can be used to create a release branch that will then be used to promote the appropriate changes into a new environment branch. This can be run multiple times while adjusting various version that you will be using with a release.The following parameters can be passed to it:
+
+| Variable | Description | Required |
+|:---------|:------------|:---------|
+|name|Name of the release. This will be used for naming the release branch and label for a release.|yes|
+|frontend|The version to use for the frontend application|no|
+|backend|The version to use for the backend application|no|
+|gitapi|The version to use for the Git API|no|
+|dispatcher|The version to use for the Resource Dispatcher|no|
+|agnosticv|The version to use for AgnosticV|no|
+|anarchy|The version to use for Anarchy|no|
+|poolboy|The version to use for Poolboy|no|
+
+`/promote` - This trigger along with the appropriate parameters can be used to promote the changes contained in a release branch into a specified environment branch that ArgoCD is watching. These promotions are auto-merged, so you should be sure that you are ready for a promotion when you run this command. It accepts that following parameters:
+
+| Variable | Description | Required | 
+|:---------|:------------|:---------|
+|name|Name of the release.|yes|
+|env|The name of the environment branch that you wish to merge your changes into|yes|
+


### PR DESCRIPTION
This adds some initial functionality to create releases and promote changes between environments via chat ops in an issue comment. This set of workflows does the following:

- Adds the release and promote actions
- When a release branch is created via the `/release` command, a release branch is created with an appropriate name, a label with that name is created and the label is then applied to that issue
- When you promote that release from the release branch to an environment branch, a PR is created, the label for that version is applied to that PR and then the PR is auto-merged