### PR TITLE
Set Anarchy route hostname

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -125,6 +125,8 @@ applications:
       name: omp-babylon-operators
     openshift:
       enabled: true
+      route:
+        host: anarchy.apps.test.lodestar.rht-labs.com
   ignoreDifferences:
   - group: apiextensions.k8s.io
     kind: CustomResourceDefinition


### PR DESCRIPTION
@tylerauerbeck this should bypass the Helm lookup function and instead use the provided value.
This will break anarchy in the old omp test cluster (which I think is ok)

FYI @oybed 