### PR TITLE
Use ocp4 agnosticv-operator image

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -106,8 +106,6 @@ applications:
   helmValues:
     anarchy:
       namespace: omp-babylon-operators
-    image:
-      tagOverride: v0.1.0-ocp3
     namespace:
       create: false
       name: omp-babylon-operators


### PR DESCRIPTION
We no longer need to use the custom ocp3 image of Agnosticv operator and can use the default ocp4 supported one.