### PR TITLE
Remove openshift-acme; Add cert-manager

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -153,4 +153,4 @@ applications:
   url: https://github.com/jetstack/cert-manager.git
   path: deploy
   ref: *certManagerVersion
-  deploymentNamespace: omp-argo-cd
+  deploymentNamespace: cluster-ops 

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -151,6 +151,9 @@ applications:
 
 - name: cert-manager
   url: https://github.com/jetstack/cert-manager.git
-  path: deploy
+  path: deploy/charts
   ref: *certManagerVersion
-  deploymentNamespace: cluster-ops 
+  deploymentNamespace: cluster-ops
+  helmValues:
+    extraArgs:
+      - --dns01-recursive-nameservers=8.8.8.8:53\,1.1.1.1:53

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -16,7 +16,8 @@ applicationVersions:
   agnosticv-operator: &agnosticvVersion helm_chart
   anarchy-operator: &anarchyVersion helm_chart
   poolboy: &poolboyVersion helm_chart
-  openshift-acme: &openshiftAcmeVersion 63cf912f507dd7cd060c86e592bd675e8e87374c
+  cert-manager: &certManagerVersion v0.15.0
+
 
 ##################################
 # Application Template Definitions
@@ -148,8 +149,8 @@ applications:
     jsonPointers:
     - /spec/names/shortNames
 
-- name: openshift-acme
-  url: https://github.com/tnozicka/openshift-acme
-  path: deploy/cluster-wide
-  ref: *openshiftAcmeVersion
-  deploymentNamespace: omp-openshift-acme
+- name: cert-manager
+  url: https://github.com/jetstack/cert-manager.git
+  path: deploy
+  ref: *certManagerVersion
+  deploymentNamespace: omp-argo-cd


### PR DESCRIPTION
This PR removes the openshift-acme deployment and replaces it with cert-manager (deployed in the omp-argo-cd namespace). This is just the application itself and not any of the custom configurations to have it take any action inside of the cluster.

cc/ @paulbarfuss @pabrahamsson @oybed 