### PR TITLE
Switch to helm chart; Update template

### DIFF
--- a/applications/templates/application.yaml
+++ b/applications/templates/application.yaml
@@ -10,13 +10,20 @@ spec:
     server: {{ $.Values.server | default "https://kubernetes.default.svc" }}
   project: default
   source:
+    {{- if .chartPath }}
+    chart: {{ .chartPath }}
+    {{- else }}
     path: {{ .path | default "." | quote }}
+    {{- end }}
     repoURL: {{ .url | quote }}
     targetRevision: {{ .ref | default "master" | quote }}
     {{- if .helmValues }}
     helm:
       values: |-
         {{- toYaml .helmValues | nindent 8 }}
+    {{- end }}
+    {{- if .chartPath }}
+    chart: {{ .chartPath }}
     {{- end }}
   {{- if .ignoreDifferences }}
   ignoreDifferences:

--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -150,8 +150,8 @@ applications:
     - /spec/names/shortNames
 
 - name: cert-manager
-  url: https://github.com/jetstack/cert-manager.git
-  path: deploy/charts/cert-manager
+  url: https://charts.jetstack.io 
+  chartPath: cert-manager
   ref: *certManagerVersion
   deploymentNamespace: cluster-ops
   helmValues:


### PR DESCRIPTION
This adds the ability to specify helm chart repos instead of just git repositories (and then utilizes this for the cert-manager application)