### PR TITLE
Update chart version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,6 +108,12 @@ jobs:
       uses: mikefarah/yq@3.3.2
       with:
         cmd: "yq w -i --anchorName poolboyVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.poolboy ${{ github.event.client_payload.slash_command.poolboy }}"
+    - name: Update Chart & App Versions
+      uses: jacobsee/github-actions/set-helm-version@master
+      with:
+        path: applications
+        chart_version: ${{ github.event.client_payload.slash_command.name }}
+        app_version: ${{ github.event.client_payload.slash_command.name }}
     - name: Commit changes
       uses: stefanzweifel/git-auto-commit-action@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       with:
         cmd: "yq w -i --anchorName poolboyVersion $GITHUB_WORKSPACE/applications/values.yaml applicationVersions.poolboy ${{ github.event.client_payload.slash_command.poolboy }}"
     - name: Update Chart & App Versions
-      uses: jacobsee/github-actions/set-helm-version@master
+      uses: redhat-cop/github-actions/set-helm-version@master
       with:
         path: applications
         chart_version: ${{ github.event.client_payload.slash_command.name }}


### PR DESCRIPTION
Updates the chart version and app version of the `applications` chart upon release initiated by GitHub Actions. Will not work until https://github.com/redhat-cop/github-actions/pull/26 is merged