### PR TITLE
Add cert-manager api groups to cluster-reader (test environment)

### DIFF
--- a/bootstrap/resources/omp-cluster-reader.yaml
+++ b/bootstrap/resources/omp-cluster-reader.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
 rules:
-- apiGroups: ["argoproj.io","anarchy.gpte.redhat.com","gpte.redhat.com","poolboy.gpte.redhat.com"]
+- apiGroups: ["argoproj.io","anarchy.gpte.redhat.com","gpte.redhat.com","poolboy.gpte.redhat.com","acme.cert-manager.io","cert-manager.io"]
   resources: ["*"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["*"]


### PR DESCRIPTION
This PR will allow us to see cert-manager resources on our non-admin users in the test environment.