### PR TITLE
Mirror the contents of application.yaml from the master branch

### DIFF
--- a/applications/templates/application.yaml
+++ b/applications/templates/application.yaml
@@ -10,13 +10,25 @@ spec:
     server: {{ $.Values.server | default "https://kubernetes.default.svc" }}
   project: default
   source:
+    {{- if .chartPath }}
+    chart: {{ .chartPath }}
+    {{- else }}
     path: {{ .path | default "." | quote }}
+    {{- end }}
     repoURL: {{ .url | quote }}
     targetRevision: {{ .ref | default "master" | quote }}
     {{- if .helmValues }}
     helm:
       values: |-
+        {{- if .helmValues.versions }}
+        {{- $appVersion := dict "versions" (dict "lodestar" $.Chart.AppVersion) }}
+        {{- toYaml (merge .helmValues $appVersion) | nindent 8 }}
+        {{- else }}
         {{- toYaml .helmValues | nindent 8 }}
+        {{- end }}
+    {{- end }}
+    {{- if .chartPath }}
+    chart: {{ .chartPath }}
     {{- end }}
   {{- if .ignoreDifferences }}
   ignoreDifferences:


### PR DESCRIPTION
The lodestar-deployment/applications/templates/application.yaml is not reflecting the same contents from the master branch and it's currently breaking ArgoCD workflow because it's unable to recognize a Helm repository from a Git repository.

This change makes sure that ArgoCD is aware that the repository specified is a Helm repo rather than a Git repo.