### PR TITLE
enable e2e tests for test env

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -32,6 +32,8 @@ applications:
   ref: *frontendVersion
   helmValues:
     imageTag: *frontendVersion
+    e2eTestJob:
+      enabled: true
   ignoreDifferences:
   - group: apps.openshift.io
     kind: DeploymentConfig


### PR DESCRIPTION
- Enables e2e test job for test env (invoked by argo post sync hook).
- To avoid the tests running in other envs the current process requires a manual merge. A further enhancement will automate this step via github action.