### PR TITLE
Define Deployment Namespace for LodeStar Status

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -72,6 +72,7 @@ applications:
   deploymentNamespace: omp-frontend
   ref: *statusVersion
   helmValues:
+    deploymentNamespace: omp-frontend
     imageTag: *statusVersion
     versions:
       frontend: *frontendVersion


### PR DESCRIPTION
- deploymentNamespace will be used in the lodestar-status helm charts to create the rolebinding