### PR TITLE
Upgrade to latest versions of babylon operators

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -14,9 +14,9 @@ applicationVersions:
   git-api: &gitApiVersion master
   status: &statusVersion master
   resource-dispatcher: &resourceDispatcherVersion master
-  agnosticv-operator: &agnosticvVersion helm_chart
-  anarchy-operator: &anarchyVersion helm_chart
-  poolboy: &poolboyVersion helm_chart
+  agnosticv-operator: &agnosticvVersion v0.1.2
+  anarchy-operator: &anarchyVersion add_dependencies_to_helm_chart
+  poolboy: &poolboyVersion v0.3.7
   cert-manager: &certManagerVersion v0.15.0
   cert-utils-operator: &certUtilsVersion v0.1.1
 
@@ -110,13 +110,15 @@ applications:
     - /status
 
 - name: agnosticv-operator
-  url: https://github.com/pabrahamsson/agnosticv-operator.git
+  url: https://github.com/redhat-gpte-devopsautomation/agnosticv-operator.git
   path: helm
   ref: *agnosticvVersion
   deploymentNamespace: omp-babylon-operators
   helmValues:
     anarchy:
       namespace: omp-babylon-operators
+    image:
+      repository: quay.io/redhat-gpte/agnosticv-operator
     namespace:
       create: false
       name: omp-babylon-operators
@@ -132,10 +134,6 @@ applications:
     namespace:
       create: false
       name: omp-babylon-operators
-    openshift:
-      enabled: true
-      route:
-        host: anarchy.apps.test.lodestar.rht-labs.com
   ignoreDifferences:
   - group: apiextensions.k8s.io
     kind: CustomResourceDefinition
@@ -143,13 +141,17 @@ applications:
     - /spec/names/shortNames
 
 - name: poolboy
-  url: https://github.com/pabrahamsson/poolboy.git
+  url: https://github.com/redhat-cop/poolboy.git
   path: helm
   ref: *poolboyVersion
   deploymentNamespace: omp-babylon-operators
   helmValues:
     anarchy:
+      create: true
       namespace: omp-babylon-operators
+      service: anarchy
+    image:
+      tagOverride: *poolboyVersion
     namespace:
       create: false
       name: omp-babylon-operators


### PR DESCRIPTION
This will get us to the latest versions of the three Babylon operators.

There's still one [outstanding PR for anarchy](https://github.com/redhat-cop/anarchy/pull/92) before we can track upstream directly. Once this has been merged and a new release has been made we can switch to upstream.

Because both CRDs and CRs are part of the Poolboy helm chart there's a chance that Argo will choke on bootstrap if the `resourceprovider` CRD hasn't been synced across etcd before the CR is being created.

There is also a chance the operators will be unhappy if Argo syncs them before the runtime config since the runtime config is responsible for creating the shared namespace. This should sort itself out once Argo has synced the runtime config.