### PR TITLE
Fixing set-env issue with GH actions

### DIFF
--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -17,11 +17,11 @@ jobs:
     - name: Set New Env (Integration)
       if: ${{ !contains(steps.env_info.outputs.labels, 'promoted to integration') }}
       run: |
-        echo ::set-env name=NEW_ENV::integration
+        echo "name=NEW_ENV::integration" >> $GITHUB_ENV
     - name: Set New Env (Production)
       if: ${{ contains(steps.env_info.outputs.labels, 'promoted to integration') }}
       run: |
-        echo ::set-env name=NEW_ENV::production
+        echo "name=NEW_ENV::production" >> $GITHUB_ENV
     - uses: actions/checkout@v2
       with:
         ref: ${{ steps.env_info.outputs.issuetitle }}


### PR DESCRIPTION
Per this article:
https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

And ways to fix it by using `environment files`:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files