### PR TITLE
Bumping babylon operator versions

### DIFF
--- a/applications/values.yaml
+++ b/applications/values.yaml
@@ -16,9 +16,9 @@ applicationVersions:
   git-api: &gitApiVersion master
   status: &statusVersion master
   resource-dispatcher: &resourceDispatcherVersion master
-  agnosticv-operator: &agnosticvVersion v0.1.2
-  anarchy-operator: &anarchyVersion v0.10.4
-  poolboy: &poolboyVersion v0.3.11
+  agnosticv-operator: &agnosticvVersion v0.3.0
+  anarchy-operator: &anarchyVersion v0.13.2
+  poolboy: &poolboyVersion v0.5.0
 
 ##################################
 # Application Template Definitions


### PR DESCRIPTION
Bumping the babylon operator versions:

https://github.com/redhat-gpte-devopsautomation/agnosticv-operator/releases

https://github.com/redhat-cop/anarchy/releases

https://github.com/redhat-cop/poolboy/releases