### PR TITLE
[Lodestar Integraion] Disabling e2e on integration

### DIFF
--- a/bootstrap/patches/lodestar-frontend.yaml
+++ b/bootstrap/patches/lodestar-frontend.yaml
@@ -14,5 +14,5 @@ spec:
       values: |-
         imageTag: v1.1.26
         e2eTestJob:
-          enabled: true
+          enabled: false
     targetRevision: v1.1.26


### PR DESCRIPTION
During the alignment of Test/Integration branches e2e variable was erroneously set in Integration to "true", this PR corrects that and sets the correct value of "false".