### PR TITLE
[LodeStar Integration] Bootstrap and README clean-up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Lodestar - Deployment
+# LodeStar - Deployment
 
-This repository both bootstraps and manages the deployment lifecycle of Lodestar across multiple versions. It contains a manifest which controls the release version of all individual components of Lodestar. It is meant to be used with Argo CD.
+This repository both bootstraps and manages the deployment lifecycle of LodeStar across multiple versions. It contains a manifest which controls the release version of all individual components of LodeStar. It is meant to be used with Argo CD.
 
 ## Bootstrapping
 
-To create an instance of Lodestar in a cluster, ensure you're on the branch/commit-id of your choice and you have working oc/kubectl session towards the target cluster, then  apply the `bootstrap` Kustomize using the following command:
+To create an instance of LodeStar in a cluster of your choice, ensure you're on the branch/commit-id of your choice and you have working oc/kubectl session towards the target cluster, then  apply the `bootstrap` Kustomize using the following command:
 
 ```sh
 kustomize build bootstrap/ | oc apply -f -
@@ -14,34 +14,11 @@ NOTE: Running `kustomize build bootstrap/` alone will print manifests that can b
 
 ## Lifecycle Management
 
-Lodestar is not a single application, but a collection of components (or services) that all add up to a working system. Those services might be versioned separately from one another. Therefore, a "deployment of Lodestar" is really a manifest of the versions of its constituent components that are known to work well with each other.
+LodeStar is not a single application, but a collection of components (or services) that all add up to a working system. Those services might be versioned separately from one another. Therefore, a "deployment of LodeStar" is really a manifest of the versions of its constituent components that are known to work well with each other.
 
-Kustomize patches for respective components live in `bootstrap/patches/` directory:
+Kustomize patches for respective components live in `bootstrap/patches/` directory.
 
-Example file, where `v1.3.1` is target version, `bootstrap/patches/lodestar-backend.yaml`: 
-
-```yaml
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: lodestar-backend
-  namespace: lodestar-argo-cd
-spec:
-  ignoreDifferences:
-  - group: apps.openshift.io
-    jsonPointers:
-    - /spec/template/spec/containers/0/image
-    - /spec/template/spec/volumes/0
-    kind: DeploymentConfig
-  source:
-    helm:
-      values: |-
-        imageTag: v1.3.1
-        mongodb:
-          persistent: false
-    targetRevision: v1.3.1
-
-```
+NOTE: Depending on the component, version can be stored in either `targetRevision` variable, or `targetRevision` and `imageTag` variables.
 
 Automatic syncing, pruning, and self healing is enabled for this project - so committing a change to the above manifest and tagging it appropriately as `deploy-staging` or `deploy-production` will cause an Argo CD instance bootstrapped with that tag to deploy those versions of the applications.
 
@@ -57,6 +34,7 @@ Creating releases is automated through the use of GitHub Actions Workflows. To c
 |backend|The version to use for the backend application|no|
 |gitapi|The version to use for the Git API|no|
 |dispatcher|The version to use for the Resource Dispatcher|no|
+|activity|The version to use for activity application|no|
 |agnosticv|The version to use for AgnosticV|no|
 |anarchy|The version to use for Anarchy|no|
 |poolboy|The version to use for Poolboy|no|

--- a/README.md
+++ b/README.md
@@ -16,19 +16,32 @@ Make sure to replace `<desired-git-ref>` with the tag that you want to deploy to
 
 Lodestar is not a single application, but a collection of components (or services) that all add up to a working system. Those services might be versioned separately from one another. Therefore, a "deployment of Lodestar" is really a manifest of the versions of its constituent components that are known to work well with each other.
 
-This manifest lives in `applications/values.yaml`:
+Manifests for respective components live in `bootstrap/patches/` directory:
+
+Example file, where `v1.3.1` is target version, `bootstrap/patches/lodestar-backend.yaml`: 
 
 ```yaml
-applicationVersions:
-  frontend: &frontendVersion 4edb30
-  backend: &backendVersion 3a03d2
-  git-api: &gitApiVersion 8cb605
-  launcher: &launcherVersion 8bca47
-  ...
-  appName: &yamlAnchorName <ref-to-deploy>
-```
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: lodestar-backend
+  namespace: lodestar-argo-cd
+spec:
+  ignoreDifferences:
+  - group: apps.openshift.io
+    jsonPointers:
+    - /spec/template/spec/containers/0/image
+    - /spec/template/spec/volumes/0
+    kind: DeploymentConfig
+  source:
+    helm:
+      values: |-
+        imageTag: v1.3.1
+        mongodb:
+          persistent: false
+    targetRevision: v1.3.1
 
-NOTE: Because Helm does not support templating inside of the `values.yaml` file, we need to use [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html) if we want to prevent duplicate definitions of data.
+```
 
 Automatic syncing, pruning, and self healing is enabled for this project - so committing a change to the above manifest and tagging it appropriately as `deploy-staging` or `deploy-production` will cause an Argo CD instance bootstrapped with that tag to deploy those versions of the applications.
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ This repository both bootstraps and manages the deployment lifecycle of Lodestar
 
 ## Bootstrapping
 
-To create an instance of Lodestar in a cluster, apply the `bootstrap` Helm chart using the following command:
+To create an instance of Lodestar in a cluster, ensure you're on the branch/commit-id of your choice and you have working oc/kubectl session towards the target cluster, then  apply the `bootstrap` Kustomize using the following command:
 
 ```sh
-helm install lodestar bootstrap/ --set application.ref=<desired git ref>
+kustomize build bootstrap/ | oc apply -f -
 ```
 
-Make sure to replace `<desired-git-ref>` with the tag that you want to deploy to this cluster. If this is a staging cluster, you might have a Git tag such as `deploy-staging`; and if this is a production cluster, maybe `deploy-production`.
+NOTE: Running `kustomize build bootstrap/` alone will print manifests that can be reviewed before actually applying it to the cluster.
 
 ## Lifecycle Management
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Creating releases is automated through the use of GitHub Actions Workflows. To c
 |gitapi|The version to use for the Git API|no|
 |dispatcher|The version to use for the Resource Dispatcher|no|
 |activity|The version to use for activity application|no|
+|artifacts|The version to use for artifacts application|no|
+|participants|The version to use for participants application|no|
 |agnosticv|The version to use for AgnosticV|no|
 |anarchy|The version to use for Anarchy|no|
 |poolboy|The version to use for Poolboy|no|

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ NOTE: Running `kustomize build bootstrap/` alone will print manifests that can b
 
 Lodestar is not a single application, but a collection of components (or services) that all add up to a working system. Those services might be versioned separately from one another. Therefore, a "deployment of Lodestar" is really a manifest of the versions of its constituent components that are known to work well with each other.
 
-Manifests for respective components live in `bootstrap/patches/` directory:
+Kustomize patches for respective components live in `bootstrap/patches/` directory:
 
 Example file, where `v1.3.1` is target version, `bootstrap/patches/lodestar-backend.yaml`: 
 

--- a/bootstrap/patches/lodestar-status.yaml
+++ b/bootstrap/patches/lodestar-status.yaml
@@ -20,7 +20,7 @@ spec:
           lodestar-git-api: v1.2.1
           lodestar-status: v1.1.0
           lodestar-config: v1.0.0
-          resource-dispatcher: v1.0.13
+          resource-dispatcher: v1.0.14
           agnosticv-operator: v0.8.1
           anarchy: v0.14.2
           poolboy: v0.6.1


### PR DESCRIPTION
Following things have been changed:
- Lodestar status service content update, resource-dispatcher has been updated but not included in status service content, this has been fixed
- Update of README.md to reflect changes to components versioning after migrating to pure Kustomize