### PR TITLE
change lodestar-config values (patch)

### DIFF
--- a/bootstrap/patches/lodestar-config.yaml
+++ b/bootstrap/patches/lodestar-config.yaml
@@ -12,12 +12,9 @@ spec:
     helm:
       values: |-
         imageTag: main
+        baseConfigMapPath: /runtime
         runtimeConfigs:
-          - name: lodestar-runtime
-            file: lodestar-runtime-config.yaml
-            path: /runtime
-          - name: lodestar-runtime-do500
-            file: lodestar-runtime-config-DO500.yaml
-            path: /runtime
+          - base
+          - DO500
     targetRevision: main
 


### PR DESCRIPTION
update to lodestar-config deployment. Configmaps use a little different naming convention which should be cleaner. Also removing subpath allows for reloading without container restart