### PR TITLE
Add Ansible Tower ClusterRole and ClusterRoleBinding

### DIFF
--- a/bootstrap/core/tools/kustomization.yaml
+++ b/bootstrap/core/tools/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
 - argocd
 - dispatcher
 - babylon
+- tower
 resources:
 - lodestar-engagements-project.yaml
 - lodestar-tools-project.yaml

--- a/bootstrap/core/tools/tower/ansible-tower-role.yaml
+++ b/bootstrap/core/tools/tower/ansible-tower-role.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+   name: ansible-tower
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - argoproj.io
+  - anarchy.gpte.redhat.com
+  - gpte.redhat.com
+  - poolboy.gpte.redhat.com
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- nonResourceURLs:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ansible-tower
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ansible-tower
+subjects:
+- kind: ServiceAccount
+  name: awx
+  namespace: lodestar-tower

--- a/bootstrap/core/tools/tower/kustomization.yaml
+++ b/bootstrap/core/tools/tower/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ansible-tower-role.yaml


### PR DESCRIPTION
This PR adds ClusterRole and ClusterRoleBinding allowing Tower to interact with OpenShift cluster on which it is deployed