### PR TITLE
[test] Ignore Poolboy state changes

### DIFF
--- a/bootstrap/core/tools/babylon/poolboy.yaml
+++ b/bootstrap/core/tools/babylon/poolboy.yaml
@@ -16,6 +16,11 @@ spec:
       kind: CustomResourceDefinition
       jsonPointers:
         - /spec/names/shortNames
+    - group: poolboy.gpte.redhat.com
+      kind: ResourceClaim
+      jsonPointers:
+        - /spec/vars/current_state
+        - /spec/vars/desired_state
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/patches/poolboy.yaml
+++ b/bootstrap/patches/poolboy.yaml
@@ -6,9 +6,14 @@ metadata:
 spec:
   ignoreDifferences:
   - group: apiextensions.k8s.io
-    jsonPointers:
-    - /spec/names/shortNames
     kind: CustomResourceDefinition
+    jsonPointers:
+      - /spec/names/shortNames
+  - group: poolboy.gpte.redhat.com
+    kind: ResourceClaim
+    jsonPointers:
+      - /spec/vars/current_state
+      - /spec/vars/desired_state
   source:
     helm:
       values: |-


### PR DESCRIPTION
Adds the current and desired state fields for Poolboy ResourceClaims to the Argo ignore list.

This is to avoid an edge case which results in an infinite loop of Argo re-applying ResourceClaims which results in 'update' execution runs.
