### PR TITLE
[production] Add missing crd

### DIFF
--- a/bootstrap/core/tools/babylon/catalogitems-crd.yaml
+++ b/bootstrap/core/tools/babylon/catalogitems-crd.yaml
@@ -1,0 +1,51 @@
+---
+
+# Reference: https://git.io/JzB3m
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogitems.babylon.gpte.redhat.com
+spec:
+  group: babylon.gpte.redhat.com
+  names:
+    kind: CatalogItem
+    listKind: CatalogItemList
+    plural: catalogitems
+    singular: catalogitem
+  scope: Namespaced
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    subresources:
+      status: {}
+    schema:
+      openAPIV3Schema:
+        description: Catalog item for Babylon
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            properties:
+              name:
+                maxLength: 63
+                pattern: ^[a-z0-9A-Z]([a-z0-9A-Z\-._]*[a-z0-9A-Z])?$
+                type: string
+            type: object
+          spec:
+            description: Specification of CatalogItem
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: Status of CatalogItem
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - apiVersion
+        - kind
+        - metadata
+        - spec
+        type: object

--- a/bootstrap/core/tools/babylon/kustomization.yaml
+++ b/bootstrap/core/tools/babylon/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - anarchy-operator.yaml
   - kopfpeering-crd.yaml
   - poolboy.yaml
+  - catalogitems-crd.yaml
 patches:
   - patch: |-
       - op: add
@@ -20,4 +21,3 @@ patches:
     target:
       group: argoproj.io
       kind: Application
-


### PR DESCRIPTION
Adds a Babylon CRD (to the production branch) for CatalogItems that are generated by the AgnosticV Operator.

For additional info see this internal [link](https://gitlab.consulting.redhat.com/rht-labs/labs-sre/documentation/-/wikis/PM-2021-09-22)