### PR TITLE
[test] Update Babylon Operators

### DIFF
--- a/bootstrap/core/tools/babylon/agnosticv-operator.yaml
+++ b/bootstrap/core/tools/babylon/agnosticv-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "helm"
     repoURL: "https://github.com/redhat-gpte-devopsautomation/agnosticv-operator.git"
-    targetRevision: "v0.14.4"
+    targetRevision: "v0.15.8"
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/core/tools/babylon/anarchy-operator.yaml
+++ b/bootstrap/core/tools/babylon/anarchy-operator.yaml
@@ -9,8 +9,8 @@ spec:
   project: default
   source:
     path: "helm"
-    repoURL: https://github.com/redhat-cop/anarchy.git 
-    targetRevision: v0.16.25
+    repoURL: https://github.com/redhat-cop/anarchy.git
+    targetRevision: v0.17.3
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/core/tools/babylon/poolboy.yaml
+++ b/bootstrap/core/tools/babylon/poolboy.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "helm"
     repoURL: "https://github.com/redhat-cop/poolboy.git"
-    targetRevision: "v0.10.2"
+    targetRevision: "v0.10.8"
   ignoreDifferences:
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition

--- a/bootstrap/patches/agnosticv-operator.yaml
+++ b/bootstrap/patches/agnosticv-operator.yaml
@@ -14,4 +14,4 @@ spec:
         namespace:
           create: false
           name: lodestar-babylon-operators
-    targetRevision: v0.14.4
+    targetRevision: v0.15.8

--- a/bootstrap/patches/anarchy-operator.yaml
+++ b/bootstrap/patches/anarchy-operator.yaml
@@ -15,4 +15,4 @@ spec:
         namespace:
           create: false
           name: lodestar-babylon-operators
-    targetRevision: v0.16.25
+    targetRevision: v0.17.3

--- a/bootstrap/patches/lodestar-status.yaml
+++ b/bootstrap/patches/lodestar-status.yaml
@@ -27,8 +27,8 @@ spec:
           lodestar-hosting: main
           lodestar-participants: main
           resource-dispatcher: master
-          agnosticv-operator: v0.14.4
-          anarchy: v0.16.25
-          poolboy: v0.10.2
+          agnosticv-operator: v0.15.8
+          anarchy: v0.17.3
+          poolboy: v0.10.8
           lodestar: 1.2.0
     targetRevision: master

--- a/bootstrap/patches/poolboy.yaml
+++ b/bootstrap/patches/poolboy.yaml
@@ -24,4 +24,4 @@ spec:
             namespace:
               create: false
               name: lodestar-babylon-operators
-    targetRevision: v0.10.2
+    targetRevision: v0.10.8


### PR DESCRIPTION
# Overview

**Environment:** Test

1. Updates the Babylon Operators in for the environment to:

  - AgnosticV v0.15.8
  - Poolboy v0.10.8
  - Anarchy v0.17.3 [thread](https://chat.google.com/room/AAAA9Rwqf0c/zm-uoOMRBxE)

  [Reference](https://github.com/redhat-cop/babylon/blob/main/openshift/config/common/vars.yaml)

2. Disables creation of 'babylon' ResourceProvider which is deprecated

  [Reference](https://github.com/rht-labs/lodestar-deployment/pull/365)
