### PR TITLE
[integration] Ignore Poolboy state changes

### DIFF
--- a/bootstrap/core/tools/babylon/poolboy.yaml
+++ b/bootstrap/core/tools/babylon/poolboy.yaml
@@ -16,8 +16,12 @@ spec:
       kind: CustomResourceDefinition
       jsonPointers:
         - /spec/names/shortNames
+    - group: poolboy.gpte.redhat.com
+      kind: ResourceClaim
+      jsonPointers:
+        - /spec/vars/current_state
+        - /spec/vars/desired_state
   syncPolicy:
     automated:
       prune: true
       selfHeal: true
-

--- a/bootstrap/patches/poolboy.yaml
+++ b/bootstrap/patches/poolboy.yaml
@@ -9,6 +9,11 @@ spec:
     jsonPointers:
     - /spec/names/shortNames
     kind: CustomResourceDefinition
+  - group: poolboy.gpte.redhat.com
+    kind: ResourceClaim
+    jsonPointers:
+      - /spec/vars/current_state
+      - /spec/vars/desired_state
   source:
     helm:
       values: |-


### PR DESCRIPTION
Adds the current and desired state fields for Poolboy ResourceClaims to the Argo ignore list.

This is to avoid an edge case which results in an infinite loop of Argo re-applying ResourceClaims which results in 'update' execution runs.

Test PR #349