### PR TITLE
Remove hardcoded image version for ArgoCD CR

### DIFF
--- a/bootstrap/core/cluster/crd-reader.yaml
+++ b/bootstrap/core/cluster/crd-reader.yaml
@@ -23,7 +23,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: default
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 - kind: ServiceAccount
   name: default
   namespace: lodestar-babylon-operators

--- a/bootstrap/core/cluster/namespaces.yaml
+++ b/bootstrap/core/cluster/namespaces.yaml
@@ -2,11 +2,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: lodestar-argo-cd
----
-apiVersion: v1
-kind: Namespace
-metadata:
   name: lodestar-frontend
 ---
 apiVersion: v1

--- a/bootstrap/core/lodestar-apps/kustomization.yaml
+++ b/bootstrap/core/lodestar-apps/kustomization.yaml
@@ -24,9 +24,6 @@ patches:
     - op: add
       path: /spec/destination/namespace
       value: lodestar-frontend
-    - op: add
-      path: /metadata/namespace
-      value: lodestar-argo-cd
   target:
     group: argoproj.io
     version: v1alpha1
@@ -34,7 +31,7 @@ patches:
 - patch: |
     - op: add
       path: /metadata/namespace
-      value: lodestar-argo-cd
+      value: openshift-gitops
   target:
     group: argoproj.io
     version: v1alpha1

--- a/bootstrap/core/lodestar-apps/kustomization.yaml
+++ b/bootstrap/core/lodestar-apps/kustomization.yaml
@@ -24,6 +24,9 @@ patches:
     - op: add
       path: /spec/destination/namespace
       value: lodestar-frontend
+    - op: add
+      path: /metadata/namespace
+      value: openshift-gitops
   target:
     group: argoproj.io
     version: v1alpha1
@@ -36,4 +39,3 @@ patches:
     group: argoproj.io
     version: v1alpha1
     kind: AppProject
-

--- a/bootstrap/core/tools/argocd/argocd-clusterrolebindings.yaml
+++ b/bootstrap/core/tools/argocd/argocd-clusterrolebindings.yaml
@@ -1,76 +1,11 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-server
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/component: server
-  name: argocd-server
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: argocd-server
-subjects:
-- kind: ServiceAccount
-  name: argocd-server
-  namespace: argocd
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
-    app.kubernetes.io/name: argocd-server
+    app.kubernetes.io/managed-by: openshift-gitops
+    app.kubernetes.io/name: openshift-gitops
     app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/component: server
-  name: argocd-server
-rules:
-- apiGroups:
-  - '*'
-  resources:
-  - '*'
-  verbs:
-  - delete  # supports deletion a live object in UI
-  - get     # supports viewing live object manifest in UI
-  - patch   # supports `argocd app patch`
-- apiGroups:
-  - ""
-  resources:
-  - events
-  verbs:
-  - list    # supports listing events in UI
-- apiGroups:
-  - ""
-  resources:
-  - pods
-  - pods/log
-  verbs:
-  - get     # supports viewing pod logs from UI
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/component: application-controller
-  name: argocd-application-controller
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: argocd-application-controller
-subjects:
-- kind: ServiceAccount
-  name: argocd-application-controller
-  namespace: argocd
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: argocd-application-controller
-    app.kubernetes.io/part-of: argocd
-    app.kubernetes.io/component: application-controller
   name: argocd-application-controller
 rules:
 - apiGroups:
@@ -79,16 +14,39 @@ rules:
   - '*'
   verbs:
   - '*'
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - patch
 - apiGroups:
   - argoproj.io
   - anarchy.gpte.redhat.com
   - gpte.redhat.com
   - poolboy.gpte.redhat.com
   resources:
-  - "*"
+  - '*'
   verbs:
-  - "*"
+  - '*'
 - nonResourceURLs:
   - '*'
   verbs:
   - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/managed-by: openshift-gitops
+    app.kubernetes.io/name: openshift-gitops
+    app.kubernetes.io/part-of: argocd
+  name: argocd-application-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: argocd-application-controller
+subjects:
+- kind: ServiceAccount
+  name: openshift-gitops-argocd-application-controller
+  namespace: openshift-gitops

--- a/bootstrap/core/tools/argocd/argocd-operator-cr.yaml
+++ b/bootstrap/core/tools/argocd/argocd-operator-cr.yaml
@@ -4,7 +4,6 @@ kind: ArgoCD
 metadata:
   name: lodestar-argocd
 spec:
-  version: v1.6.2
   rbac:
     defaultPolicy: 'role:readonly'
   server:

--- a/bootstrap/core/tools/argocd/argocd-operator-cr.yaml
+++ b/bootstrap/core/tools/argocd/argocd-operator-cr.yaml
@@ -2,7 +2,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: ArgoCD
 metadata:
-  name: lodestar-argocd
+  name: openshift-gitops
 spec:
   rbac:
     defaultPolicy: 'role:readonly'

--- a/bootstrap/core/tools/argocd/kustomization.yaml
+++ b/bootstrap/core/tools/argocd/kustomization.yaml
@@ -1,13 +1,12 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- argocd-clusterrolebindings.yaml
 - argocd-operator-cr.yaml
 patches:
   - patch: |
       - op: add
         path: /metadata/namespace
-        value: lodestar-argo-cd
+        value: openshift-gitops
     target:
       group: argoproj.io
       version: v1alpha1
@@ -15,7 +14,7 @@ patches:
   - patch: |
       - op: replace
         path: /subjects/0/namespace
-        value: lodestar-argo-cd
+        value: openshift-gitops
     target:
       labelSelector: app.kubernetes.io/part-of=argocd
       kind: ClusterRoleBinding

--- a/bootstrap/core/tools/babylon/kustomization.yaml
+++ b/bootstrap/core/tools/babylon/kustomization.yaml
@@ -14,7 +14,7 @@ patches:
         value: lodestar-tools
       - op: add
         path: /metadata/namespace
-        value: lodestar-argo-cd
+        value: openshift-gitops
       - op: add
         path: /spec/destination/namespace
         value: lodestar-babylon-operators

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -90,4 +90,4 @@ tasks:
           mode: in-cluster
           apply_objects:
             from_dir: "."
-            namespace: "lodestar-argo-cd"
+            namespace: "openshift-gitops"

--- a/bootstrap/core/tools/dispatcher/kustomization.yaml
+++ b/bootstrap/core/tools/dispatcher/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - resource-dispatcher.yaml
 configMapGenerator:
 - name: resource-dispatcher-config
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
   files:
   - configs/day-two-daily.yml
   - configs/gitlab-to-argo.yml
@@ -16,10 +16,10 @@ patches:
 - patch: |-
     - op: add
       path: /spec/destination/namespace
-      value: lodestar-argo-cd
+      value: openshift-gitops
     - op: add
       path: /metadata/namespace
-      value: lodestar-argo-cd
+      value: openshift-gitops
     - op: add
       path: /spec/project
       value: lodestar-tools

--- a/bootstrap/core/tools/kustomization.yaml
+++ b/bootstrap/core/tools/kustomization.yaml
@@ -12,7 +12,7 @@ patches:
   - patch: |
       - op: add
         path: /metadata/namespace
-        value: lodestar-argo-cd
+        value: openshift-gitops
     target:
       group: argoproj.io
       version: v1alpha1

--- a/bootstrap/core/tools/restart-configurable-resources.yaml
+++ b/bootstrap/core/tools/restart-configurable-resources.yaml
@@ -3,7 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: reload-configurable-resources
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
   annotations:
     argocd.argoproj.io/hook: PostSync
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
@@ -23,10 +23,10 @@ spec:
           oc rollout latest dc/lodestar-activity -n lodestar-frontend  || echo "deployment config lodestar-activity does not exist"
           oc rollout latest dc/lodestar-participants -n lodestar-frontend  || echo "deployment config lodestar-participants does not exist"
           oc rollout latest dc/lodestar-artifacts -n lodestar-frontend  || echo "deployment config lodestar-artifacts does not exist"
-          oc rollout latest dc/resource-dispatcher -n lodestar-argo-cd || echo "deployment config resource-dispatcher does not exist"
+          oc rollout latest dc/resource-dispatcher -n openshift-gitops || echo "deployment config resource-dispatcher does not exist"
       restartPolicy: Never
       terminationGracePeriodSeconds: 30
       activeDeadlineSeconds: 500
       dnsPolicy: ClusterFirst
-      serviceAccountName: argocd-application-controller
-      serviceAccount: argocd-application-controller
+      serviceAccountName: openshift-gitops-argocd-application-controller
+      serviceAccount: openshift-gitops-argocd-application-controller

--- a/bootstrap/patches/agnosticv-operator.yaml
+++ b/bootstrap/patches/agnosticv-operator.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: agnosticv-operator
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   source:
     helm:

--- a/bootstrap/patches/anarchy-operator.yaml
+++ b/bootstrap/patches/anarchy-operator.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: anarchy-operator
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apiextensions.k8s.io

--- a/bootstrap/patches/lodestar-activity.yaml
+++ b/bootstrap/patches/lodestar-activity.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-activity
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-artifacts.yaml
+++ b/bootstrap/patches/lodestar-artifacts.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-artifacts
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-backend.yaml
+++ b/bootstrap/patches/lodestar-backend.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-backend
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-engagement-status.yaml
+++ b/bootstrap/patches/lodestar-engagement-status.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-engagement-status
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-frontend.yaml
+++ b/bootstrap/patches/lodestar-frontend.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-frontend
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-git-api.yaml
+++ b/bootstrap/patches/lodestar-git-api.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-git-api
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-hosting.yaml
+++ b/bootstrap/patches/lodestar-hosting.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-hosting
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-participants.yaml
+++ b/bootstrap/patches/lodestar-participants.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-participants
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/lodestar-status.yaml
+++ b/bootstrap/patches/lodestar-status.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-status
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io

--- a/bootstrap/patches/poolboy.yaml
+++ b/bootstrap/patches/poolboy.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: poolboy
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apiextensions.k8s.io

--- a/bootstrap/patches/resource-dispatcher.yaml
+++ b/bootstrap/patches/resource-dispatcher.yaml
@@ -2,10 +2,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: resource-dispatcher
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   destination:
-    namespace: lodestar-argo-cd
+    namespace: openshift-gitops
   ignoreDifferences:
   - group: apps.openshift.io
     jsonPointers:


### PR DESCRIPTION
That PR removes a hardcoded image version that is required for ArgoCD Community Operator, and will be causing problems when we move to GitOps Operator. On top of that, it moves all ArgoCD related resources to `openshift-gitops` project