### PR TITLE
[test] Update Babylon Operators

### DIFF
--- a/bootstrap/core/tools/babylon/agnosticv-operator.yaml
+++ b/bootstrap/core/tools/babylon/agnosticv-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "helm"
     repoURL: "https://github.com/redhat-gpte-devopsautomation/agnosticv-operator.git"
-    targetRevision: "v0.15.8"
+    targetRevision: "v0.15.9"
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/core/tools/babylon/agnosticv-operator.yaml
+++ b/bootstrap/core/tools/babylon/agnosticv-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "helm"
     repoURL: "https://github.com/redhat-gpte-devopsautomation/agnosticv-operator.git"
-    targetRevision: "v0.15.10"
+    targetRevision: "v0.16.0"
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/core/tools/babylon/agnosticv-operator.yaml
+++ b/bootstrap/core/tools/babylon/agnosticv-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "helm"
     repoURL: "https://github.com/redhat-gpte-devopsautomation/agnosticv-operator.git"
-    targetRevision: "v0.15.9"
+    targetRevision: "v0.15.10"
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/core/tools/babylon/anarchy-operator.yaml
+++ b/bootstrap/core/tools/babylon/anarchy-operator.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "helm"
     repoURL: https://github.com/redhat-cop/anarchy.git
-    targetRevision: v0.17.3
+    targetRevision: v0.18.0
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/core/tools/babylon/babylon-config.yaml
+++ b/bootstrap/core/tools/babylon/babylon-config.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: "openshift/config/common/helm/babylon-config"
     repoURL: "https://github.com/redhat-cop/babylon.git"
-    targetRevision: "v0.11.10"
+    targetRevision: "v0.12.0"
   ignoreDifferences:
     - group: apiextensions.k8s.io
       kind: CustomResourceDefinition

--- a/bootstrap/patches/agnosticv-operator.yaml
+++ b/bootstrap/patches/agnosticv-operator.yaml
@@ -14,4 +14,4 @@ spec:
         namespace:
           create: false
           name: lodestar-babylon-operators
-    targetRevision: v0.15.9
+    targetRevision: v0.15.10

--- a/bootstrap/patches/agnosticv-operator.yaml
+++ b/bootstrap/patches/agnosticv-operator.yaml
@@ -14,4 +14,4 @@ spec:
         namespace:
           create: false
           name: lodestar-babylon-operators
-    targetRevision: v0.15.10
+    targetRevision: v0.16.0

--- a/bootstrap/patches/agnosticv-operator.yaml
+++ b/bootstrap/patches/agnosticv-operator.yaml
@@ -14,4 +14,4 @@ spec:
         namespace:
           create: false
           name: lodestar-babylon-operators
-    targetRevision: v0.15.8
+    targetRevision: v0.15.9

--- a/bootstrap/patches/anarchy-operator.yaml
+++ b/bootstrap/patches/anarchy-operator.yaml
@@ -15,4 +15,4 @@ spec:
         namespace:
           create: false
           name: lodestar-babylon-operators
-    targetRevision: v0.17.3
+    targetRevision: v0.18.0

--- a/bootstrap/patches/babylon-config.yaml
+++ b/bootstrap/patches/babylon-config.yaml
@@ -22,4 +22,4 @@ spec:
             operatorNamespace: openshift-operators
             crossClusterBackup:
               enable: false
-    targetRevision: v0.11.10
+    targetRevision: v0.12.0

--- a/bootstrap/patches/lodestar-status.yaml
+++ b/bootstrap/patches/lodestar-status.yaml
@@ -27,7 +27,7 @@ spec:
           lodestar-hosting: main
           lodestar-participants: main
           resource-dispatcher: master
-          agnosticv-operator: v0.15.9
+          agnosticv-operator: v0.15.10
           anarchy: v0.18.0
           poolboy: v0.10.8
           lodestar: 1.2.0

--- a/bootstrap/patches/lodestar-status.yaml
+++ b/bootstrap/patches/lodestar-status.yaml
@@ -27,7 +27,7 @@ spec:
           lodestar-hosting: main
           lodestar-participants: main
           resource-dispatcher: master
-          agnosticv-operator: v0.15.10
+          agnosticv-operator: v0.16.0
           anarchy: v0.18.0
           poolboy: v0.10.8
           lodestar: 1.2.0

--- a/bootstrap/patches/lodestar-status.yaml
+++ b/bootstrap/patches/lodestar-status.yaml
@@ -27,8 +27,8 @@ spec:
           lodestar-hosting: main
           lodestar-participants: main
           resource-dispatcher: master
-          agnosticv-operator: v0.15.8
-          anarchy: v0.17.3
+          agnosticv-operator: v0.15.9
+          anarchy: v0.18.0
           poolboy: v0.10.8
           lodestar: 1.2.0
     targetRevision: master


### PR DESCRIPTION
# Overview

**Environment:** Test

1. Updates the Babylon Operators in for the environment to:

  - AgnosticV v0.16.0  <- This tag includes PR [#89](https://github.com/redhat-gpte-devopsautomation/agnosticv-operator/pull/89)
  - Poolboy v0.10.8
  - Anarchy v0.18.0
  - Babylon Config v0.12.0

  [Reference](https://github.com/redhat-cop/babylon/blob/main/openshift/config/common/vars.yaml)

2. This includes the AgnosticV release to add custom updateFilters to Poolboy ResourceProvider template

  [Reference](https://github.com/redhat-gpte-devopsautomation/agnosticv-operator/pull/89)
