### PR TITLE
Ignore namespace labels to avoid ArgoCD loop

### DIFF
--- a/bootstrap/patches/babylon-config.yaml
+++ b/bootstrap/patches/babylon-config.yaml
@@ -9,6 +9,9 @@ spec:
     kind: CustomResourceDefinition
     jsonPointers:
       - /spec/names/shortNames
+  - kind: Namespace
+    jsonPointers:
+      - /metadata/labels/app.kubernetes.io/instance
   source:
     helm:
       values: |-


### PR DESCRIPTION
Ignores the Namespace label to avoid an infinite loop in ArgoCD changing the label due to collision between;

- `babylon-config` setting it as `babylon-config`
- `lodestar-runtime-config` setting it as `lodestar-runtime-config`
