### PR TITLE
Add resource dispatcher debug messages

### DIFF
--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -49,6 +49,7 @@ tasks:
               try:
                 repository_tree = project.repository_tree(all=True)
               except Exception as err:
+                print("Failed to walk repository file tree, are there any files in this repository?")              
                 print(err)
                 return False
               engagement_file = [f for f in repository_tree if f["path"] == 'engagement.json']

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -78,9 +78,11 @@ tasks:
               else:
                 cloud_provider = engagement["hosting_environments"][0]["ocp_cloud_provider_name"]
               return True
+
             def do_not_process(file):
               print(f"Not processing {file}")
               os.remove(file)
+
             files = [f for f in os.listdir(".")]
             for file in files:
               project_id = file.partition(".")[0] # The project ID is the filename before ".yml"

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -48,18 +48,16 @@ tasks:
                 repository_tree = project.repository_tree(all=True)
               except Exception as err:
                 print(err)
-                print("Failed to walk repository file tree, are there any files in this repository?")
                 return False
               engagement_file = [f for f in repository_tree if f["path"] == 'engagement.json']
               if not len(engagement_file) == 1:
-                print("The Engagement file does not exist!")
                 return False
               engagement = json.loads(project.files.get('engagement.json', "master").decode())
               print("Checking Engagement: %s - %s"
                     %(engagement.get('customer_name', 'Undefined'),
                       engagement.get('project_name', 'Undefined')))
               if not ("launch" in engagement and "launched_date_time" in engagement["launch"]):
-                print("Engagement file doesn't have the correct launch data in it")
+                # Engagement file doesn't have the correct launch data in it
                 return False
               if "archive_date" in engagement:
                 try:
@@ -69,16 +67,14 @@ tasks:
                   return False
                 now_ts = datetime.utcnow().timestamp()
                 if now_ts > archive_date_ts:
+                  # We're past the engagement archive_date and should not process
                   print("Engagement has passed the archiving date")
                   return False
               if not "hosting_environments" in engagement:
-                print("Hosting environment is not defined in engagement.json")
                 return False
               if len(engagement["hosting_environments"]) == 0:
-                print("The Hosting environment section within the engagement file is empty")
                 return False
               if not "ocp_cloud_provider_name" in engagement["hosting_environments"][0]:
-                print("No Cloud Provider name was provided")
                 return False
               else:
                 cloud_provider = engagement["hosting_environments"][0]["ocp_cloud_provider_name"]

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -6,8 +6,6 @@ repositories:
 tasks:
   - name: gitlab-to-argo
     description: Ensures that all repositories in a GitLab group are being watched by an Argo CD instance
-    # TODO: Remove this once debug is complete.
-    disable_error_handling: true
     triggers:
       - type: scheduled
         every: 10 minutes
@@ -40,24 +38,19 @@ tasks:
             import os
             import gitlab
             import dateutil.parser
-
             print("Checking projects from https://{{ ENV_GITLAB_BASE_URL }}" )
             g = gitlab.Gitlab(
               "https://{{ ENV_GITLAB_BASE_URL }}" ,
               private_token="{{ ENV_GITLAB_PRIVATE_TOKEN | trim }}"
             )
-
             def should_process_project(project):
-
               try:
                 repository_tree = project.repository_tree(all=True)
               except Exception as err:
                 print(err)
                 print("Failed to walk repository file tree, are there any files in this repository?")
                 return False
-
               engagement_file = [f for f in repository_tree if f["path"] == 'engagement.json']
-
               if not len(engagement_file) == 1:
                 print("The Engagement file does not exist!")
                 return False
@@ -65,11 +58,9 @@ tasks:
               print("Checking Engagement: %s - %s"
                     %(engagement.get('customer_name', 'Undefined'),
                       engagement.get('project_name', 'Undefined')))
-
               if not ("launch" in engagement and "launched_date_time" in engagement["launch"]):
                 print("Engagement file doesn't have the correct launch data in it")
                 return False
-
               if "archive_date" in engagement:
                 try:
                   archive_date_ts = dateutil.parser.parse(engagement["archive_date"]).timestamp()
@@ -80,7 +71,6 @@ tasks:
                 if now_ts > archive_date_ts:
                   print("Engagement has passed the archiving date")
                   return False
-
               if not "hosting_environments" in engagement:
                 print("Hosting environment is not defined in engagement.json")
                 return False
@@ -93,11 +83,9 @@ tasks:
               else:
                 cloud_provider = engagement["hosting_environments"][0]["ocp_cloud_provider_name"]
               return True
-
             def do_not_process(file):
               print(f"Not processing {file}")
               os.remove(file)
-
             files = [f for f in os.listdir(".")]
             for file in files:
               project_id = file.partition(".")[0] # The project ID is the filename before ".yml"
@@ -105,7 +93,6 @@ tasks:
               print(f"Processing project id {project_id} for {project.description}")
               if not should_process_project(project):
                 do_not_process(file)
-
       - plugin: kubernetes
         repository: automation-repo
         path: gitlab-to-argo/output

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -41,24 +41,35 @@ tasks:
             import gitlab
             import dateutil.parser
 
+            print("Checking projects from https://{{ ENV_GITLAB_BASE_URL }}" )
             g = gitlab.Gitlab(
-                              "https://{{ ENV_GITLAB_BASE_URL }}" ,
-                              private_token="{{ ENV_GITLAB_PRIVATE_TOKEN | trim }}"
-                             )
+              "https://{{ ENV_GITLAB_BASE_URL }}" ,
+              private_token="{{ ENV_GITLAB_PRIVATE_TOKEN | trim }}"
+            )
 
             def should_process_project(project):
-              repository_tree = project.repository_tree(all=True)
+
+              try:
+                repository_tree = project.repository_tree(all=True)
+              except Exception as err:
+                print(err)
+                print("Failed to walk repository file tree, are there any files in this repository?")
+                return False
+
               engagement_file = [f for f in repository_tree if f["path"] == 'engagement.json']
+
               if not len(engagement_file) == 1:
                 print("The Engagement file does not exist!")
                 return False
               engagement = json.loads(project.files.get('engagement.json', "master").decode())
               print("Checking Engagement: %s - %s"
-                     %(engagement.get('customer_name', 'Undefined'),
-                       engagement.get('project_name', 'Undefined')))
+                    %(engagement.get('customer_name', 'Undefined'),
+                      engagement.get('project_name', 'Undefined')))
+
               if not ("launch" in engagement and "launched_date_time" in engagement["launch"]):
                 print("Engagement file doesn't have the correct launch data in it")
                 return False
+
               if "archive_date" in engagement:
                 try:
                   archive_date_ts = dateutil.parser.parse(engagement["archive_date"]).timestamp()
@@ -69,6 +80,7 @@ tasks:
                 if now_ts > archive_date_ts:
                   print("Engagement has passed the archiving date")
                   return False
+
               if not "hosting_environments" in engagement:
                 print("Hosting environment is not defined in engagement.json")
                 return False
@@ -81,15 +93,19 @@ tasks:
               else:
                 cloud_provider = engagement["hosting_environments"][0]["ocp_cloud_provider_name"]
               return True
+
             def do_not_process(file):
               print(f"Not processing {file}")
               os.remove(file)
+
             files = [f for f in os.listdir(".")]
             for file in files:
               project_id = file.partition(".")[0] # The project ID is the filename before ".yml"
               project = g.projects.get(project_id, lazy=False)
+              print(f"Processing project id {project_id} for {project.description}")
               if not should_process_project(project):
                 do_not_process(file)
+
       - plugin: kubernetes
         repository: automation-repo
         path: gitlab-to-argo/output

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -87,7 +87,6 @@ tasks:
             for file in files:
               project_id = file.partition(".")[0] # The project ID is the filename before ".yml"
               project = g.projects.get(project_id, lazy=False)
-              print(f"Processing project id {project_id} for {project.description}")
               if not should_process_project(project):
                 do_not_process(file)
       - plugin: kubernetes

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -68,7 +68,6 @@ tasks:
                 now_ts = datetime.utcnow().timestamp()
                 if now_ts > archive_date_ts:
                   # We're past the engagement archive_date and should not process
-                  print("Engagement has passed the archiving date")
                   return False
               if not "hosting_environments" in engagement:
                 return False

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -48,35 +48,40 @@ tasks:
               repository_tree = project.repository_tree(all=True)
               engagement_file = [f for f in repository_tree if f["path"] == 'engagement.json']
               if not len(engagement_file) == 1:
-                # Engagement file doesn't exist
+                print("The Engagement file does not exist!")
                 return False
               engagement = json.loads(project.files.get('engagement.json', "master").decode())
               print("Checking Engagement: %s - %s"
                      %(engagement.get('customer_name', 'Undefined'),
                        engagement.get('project_name', 'Undefined')))
               if not ("launch" in engagement and "launched_date_time" in engagement["launch"]):
-                # Engagement file doesn't have the correct launch data in it
+                print("Engagement file doesn't have the correct launch data in it")
                 return False
               if "archive_date" in engagement:
                 try:
                   archive_date_ts = dateutil.parser.parse(engagement["archive_date"]).timestamp()
                 except ValueError:
+                  print("Could not parse archive date: %s" %engagement["archive_date"])
                   return False
                 now_ts = datetime.utcnow().timestamp()
                 if now_ts > archive_date_ts:
-                  # We're past the engagement archive_date and should not process
+                  print("Engagement has passed the archiving date")
                   return False
-              if (not "hosting_environments" in engagement or
-                  len(engagement["hosting_environments"]) == 0 or 
-                  not "ocp_cloud_provider_name" in engagement["hosting_environments"][0] or 
-                  engagement["hosting_environments"][0]["ocp_cloud_provider_name"] != "ec2"):
+              if not "hosting_environments" in engagement:
+                print("Hosting environment is not defined in engagement.json")
                 return False
+              if len(engagement["hosting_environments"]) == 0:
+                print("The Hosting environment section within the engagement file is empty")
+                return False
+              if not "ocp_cloud_provider_name" in engagement["hosting_environments"][0]:
+                print("No Cloud Provider name was provided")
+                return False
+              else:
+                cloud_provider = engagement["hosting_environments"][0]["ocp_cloud_provider_name"]
               return True
-
             def do_not_process(file):
               print(f"Not processing {file}")
               os.remove(file)
-
             files = [f for f in os.listdir(".")]
             for file in files:
               project_id = file.partition(".")[0] # The project ID is the filename before ".yml"

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -38,6 +38,7 @@ tasks:
             import os
             import gitlab
             import dateutil.parser
+
             print("Checking projects from https://{{ ENV_GITLAB_BASE_URL }}" )
             g = gitlab.Gitlab(
               "https://{{ ENV_GITLAB_BASE_URL }}" ,

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -6,6 +6,8 @@ repositories:
 tasks:
   - name: gitlab-to-argo
     description: Ensures that all repositories in a GitLab group are being watched by an Argo CD instance
+    # TODO: Remove this once debug is complete.
+    disable_error_handling: true
     triggers:
       - type: scheduled
         every: 10 minutes

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -69,14 +69,11 @@ tasks:
                 if now_ts > archive_date_ts:
                   # We're past the engagement archive_date and should not process
                   return False
-              if not "hosting_environments" in engagement:
+              if (not "hosting_environments" in engagement or
+                  len(engagement["hosting_environments"]) == 0 or 
+                  not "ocp_cloud_provider_name" in engagement["hosting_environments"][0] or 
+                  engagement["hosting_environments"][0]["ocp_cloud_provider_name"] != "ec2"):
                 return False
-              if len(engagement["hosting_environments"]) == 0:
-                return False
-              if not "ocp_cloud_provider_name" in engagement["hosting_environments"][0]:
-                return False
-              else:
-                cloud_provider = engagement["hosting_environments"][0]["ocp_cloud_provider_name"]
               return True
 
             def do_not_process(file):

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -43,6 +43,7 @@ tasks:
               "https://{{ ENV_GITLAB_BASE_URL }}" ,
               private_token="{{ ENV_GITLAB_PRIVATE_TOKEN | trim }}"
             )
+
             def should_process_project(project):
               try:
                 repository_tree = project.repository_tree(all=True)

--- a/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/dispatcher/configs/gitlab-to-argo.yml
@@ -53,6 +53,7 @@ tasks:
                 return False
               engagement_file = [f for f in repository_tree if f["path"] == 'engagement.json']
               if not len(engagement_file) == 1:
+                # Engagement file doesn't exist
                 return False
               engagement = json.loads(project.files.get('engagement.json', "master").decode())
               print("Checking Engagement: %s - %s"


### PR DESCRIPTION
This PR,

- Adds additional debug information so you can determine the reason why the project was skipped without referring to the code.
- Handles the exception where GitLab returns a 404 and currently silently crashes resource dispatcher due to an empty repository

Example before/after debug messages;

```bash
# BEFORE
Checking Engagement: Irken Empire - Test Fields
Not processing 23172.yml
Checking Engagement: kevid - swamped
Not processing 23171.yml
Checking Engagement: kevid - undraw
Not processing 23170.yml
Checking Engagement: kevid - loyally
Not processing 23169.yml
404: 404 Tree Not Found
### Crashes here silently! ###


# AFTER
Checking projects from https://gitlab.consulting.redhat.com
Processing project id 23172 for engagement UUID: 028e1ef0-dfb2-4641-9333-ab76613ab552
Checking Engagement: Irken Empire - Test Fields
Engagement file doesn't have the correct launch data in it
Not processing 23172.yml
Processing project id 23171 for engagement UUID: 0b3f0b7a-6f61-47eb-aa99-1644947f25bb
Checking Engagement: kevid - swamped
Engagement file doesn't have the correct launch data in it
Not processing 23171.yml
Processing project id 23170 for engagement UUID: b82e19b7-451a-414e-8b24-c680943ff966
Checking Engagement: kevid - undraw
Engagement file doesn't have the correct launch data in it
Not processing 23170.yml
Processing project id 23169 for engagement UUID: 9a443420-76d3-41d3-bfe2-02f15477d87c
Checking Engagement: kevid - loyally
Engagement file doesn't have the correct launch data in it
Not processing 23169.yml
Processing project id 23110 for engagement UUID: c6723c0c-558a-4c5a-bb55-be8ac57116f0
404: 404 Tree Not Found
Failed to walk repository file tree, are there any files in this repository?
```
