### PR TITLE
Ignore all label changes

### DIFF
--- a/bootstrap/core/tools/babylon/babylon-config.yaml
+++ b/bootstrap/core/tools/babylon/babylon-config.yaml
@@ -16,6 +16,9 @@ spec:
       kind: CustomResourceDefinition
       jsonPointers:
         - /spec/names/shortNames
+    - kind: Namespace
+      jsonPointers:
+        - /metadata/labels
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/patches/babylon-config.yaml
+++ b/bootstrap/patches/babylon-config.yaml
@@ -11,7 +11,7 @@ spec:
       - /spec/names/shortNames
   - kind: Namespace
     jsonPointers:
-      - /metadata/labels/app.kubernetes.io/instance
+      - /metadata/labels
   source:
     helm:
       values: |-


### PR DESCRIPTION
Instruct ArgoCD to ignore all label changes in the babylon-config app.

This _fully_ avoids the issue below, where there is an infinite sync loop.

![broken_argo](https://user-images.githubusercontent.com/16071195/142345942-cdf286d5-48a7-439e-8ae0-9edb30e06f68.png)
