### PR TITLE
Add jqPathExpression to ignore action_schedule

### DIFF
--- a/bootstrap/core/tools/babylon/poolboy.yaml
+++ b/bootstrap/core/tools/babylon/poolboy.yaml
@@ -21,6 +21,8 @@ spec:
       jsonPointers:
         - /spec/vars/current_state
         - /spec/vars/desired_state
+      jqPathExpressions:
+        - .spec.resources.[].template.spec.vars.action_schedule
   syncPolicy:
     automated:
       prune: true

--- a/bootstrap/patches/poolboy.yaml
+++ b/bootstrap/patches/poolboy.yaml
@@ -14,6 +14,8 @@ spec:
     jsonPointers:
       - /spec/vars/current_state
       - /spec/vars/desired_state
+    jqPathExpressions:
+      - .spec.resources.[].template.spec.vars.action_schedule
   source:
     helm:
       values: |-


### PR DESCRIPTION
Add jqPathExpression to ignore modifications to `action_schedule`

This can be verified as follows;

```bash
oc get ResourceClaim -n lodestar-babylon-operators

# Choose your ResourceClaim name
RESOURCECLAIM_NAME="name_here"

oc get ResourceClaim -n lodestar-babylon-operators $RESOURCECLAIM_NAME -o yaml
```

```yaml
# snippet
  resourceHandle:
    apiVersion: poolboy.gpte.redhat.com/v1
    kind: ResourceHandle
    name: guid-cwmr5
    namespace: lodestar-babylon-operators
spec:
  resources:
  - provider:
      apiVersion: poolboy.gpte.redhat.com/v1
      kind: ResourceProvider
      name: do500.ocp4.dev
      namespace: lodestar-babylon-operators
    template:
      spec:
        vars:
          action_schedule:
            start: "2021-11-23T23:14:30Z"
            stop: "2021-11-24T01:14:30Z"
```

```bash
oc get ResourceHandle -n lodestar-babylon-operators guid-cwmr5 -o yaml
```

```yaml
# snippet
    template:
      spec:
        vars:
          action_schedule:
            start: "2021-11-23T23:14:30Z"
            stop: "2021-11-24T01:14:30Z"
```

Note that the default timeframe is short so this PR should be reviewed in conjunction with [internal PR #579](https://gitlab.consulting.redhat.com/rht-labs/labs-sre/hosting/config/-/merge_requests/579)