### PR TITLE
Fixing the use of incorrect namespace

### DIFF
--- a/bootstrap/core/tools/resource-dispatcher/resource-dispatcher-cert.yaml
+++ b/bootstrap/core/tools/resource-dispatcher/resource-dispatcher-cert.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: resource-dispatcher-cert
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   secretName: resource-dispatcher-cert
   issuerRef:

--- a/bootstrap/core/tools/resource-dispatcher/resource-dispatcher-vanity-route.yaml
+++ b/bootstrap/core/tools/resource-dispatcher/resource-dispatcher-vanity-route.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: resource-dispatcher
   name: resource-dispatcher-vanity-route
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   tls:
     insecureEdgeTerminationPolicy: Redirect

--- a/bootstrap/patches/babylon-config.yaml
+++ b/bootstrap/patches/babylon-config.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: babylon-config
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apiextensions.k8s.io

--- a/bootstrap/patches/lodestar-engagements.yaml
+++ b/bootstrap/patches/lodestar-engagements.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: lodestar-engagements
-  namespace: lodestar-argo-cd
+  namespace: openshift-gitops
 spec:
   ignoreDifferences:
   - group: apps.openshift.io


### PR DESCRIPTION
With the merge of PR https://github.com/rht-labs/lodestar-deployment/pull/359 and https://github.com/rht-labs/lodestar-deployment/pull/449, a couple of namespaces were left behind on the old `lodestar-argo-cd` reference. This PR fixes this issue. 