### PR TITLE
Move ResourceClaim ignore filters from Application to an ArgoCD object

### DIFF
--- a/bootstrap/core/tools/argocd/argocd-operator-cr.yaml
+++ b/bootstrap/core/tools/argocd/argocd-operator-cr.yaml
@@ -16,3 +16,7 @@ spec:
         jsonPointers:
           - /status
           - /status/ingress
+    poolboy.gpte.redhat.com/ResourceClaim:
+      ignoreDifferences: |
+        jqPathExpressions:
+          - .spec.resources.[].template.spec.vars.action_schedule


### PR DESCRIPTION
This PR adds ResourceClaims jqPathExpressions filters on the ArgoCD object as a part of global Argo configuration,
instead of defining that on the level of specific Application .