### PR TITLE
Moving lodestar-automation to labs-sre-automation

### DIFF
--- a/bootstrap/core/tools/resource-dispatcher/configs/day-two-daily.yml
+++ b/bootstrap/core/tools/resource-dispatcher/configs/day-two-daily.yml
@@ -1,6 +1,6 @@
 repositories:
   - name: automation-repo
-    url: https://github.com/rht-labs/lodestar-automation.git
+    url: https://github.com/rht-labs/labs-sre-automation.git
     ref: master
 
   - name: infra-ansible

--- a/bootstrap/core/tools/resource-dispatcher/configs/gitlab-to-argo.yml
+++ b/bootstrap/core/tools/resource-dispatcher/configs/gitlab-to-argo.yml
@@ -1,6 +1,6 @@
 repositories:
   - name: automation-repo
-    url: https://github.com/rht-labs/lodestar-automation.git
+    url: https://github.com/rht-labs/labs-sre-automation.git
     ref: master
 
 tasks:

--- a/bootstrap/core/tools/resource-dispatcher/configs/translate-engagement-data.yml
+++ b/bootstrap/core/tools/resource-dispatcher/configs/translate-engagement-data.yml
@@ -1,6 +1,6 @@
 repositories:
   - name: automation-repo
-    url: https://github.com/rht-labs/lodestar-automation.git
+    url: https://github.com/rht-labs/labs-sre-automation.git
     ref: master
 
 tasks:

--- a/bootstrap/core/tools/resource-dispatcher/configs/update-statuses.yml
+++ b/bootstrap/core/tools/resource-dispatcher/configs/update-statuses.yml
@@ -1,6 +1,6 @@
 repositories:
   - name: automation-repo
-    url: https://github.com/rht-labs/lodestar-automation.git
+    url: https://github.com/rht-labs/labs-sre-automation.git
     ref: master
 
 tasks:


### PR DESCRIPTION
The repo was renamed awhile back, so this PR makes sure to reference the new name